### PR TITLE
Remove useless method

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,8 +57,4 @@ impl<const N: usize, const M: usize, E: IsNumber + Default + Copy> Matrix<N, M, 
     pub const fn columns(&self) -> usize {
         M
     }
-
-    pub fn say_hi(&self) {
-        println!("Hi from this matrix");
-    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,6 @@ fn main() {
     let manual = matrix![[[1, 2, 3], [4, 5, 6]]];
     let squared = Matrix::<2, 2>::square(1);
     let rows = squared.rows();
+
     println!("{squared:?}");
-    manual.say_hi();
 }


### PR DESCRIPTION
Looking at the code of this library it seems to me a little out of context the function say_hi, which does not make much sense.
```rust
 pub fn say_hi(&self) {
        println!("Hi from this matrix");
    }
```
the purpose of this pull request is to remove this method and also to remove it from main.rs